### PR TITLE
[16.0][FIX] shopinvader_api_delivery_carrier: compute delivery price for all delivery types

### DIFF
--- a/shopinvader_api_delivery_carrier/routers/cart.py
+++ b/shopinvader_api_delivery_carrier/routers/cart.py
@@ -54,7 +54,7 @@ class ShopinvaderApiCartRouterHelper(models.AbstractModel):
         ctx = self.env.context.copy()
         ctx.update({"default_order_id": cart.id, "default_carrier_id": carrier_id})
         wizard = self.env["choose.delivery.carrier"].with_context(**ctx).create({})
-        wizard._onchange_carrier_id()
+        wizard._get_shipment_rate()
         wizard.button_confirm()
         return wizard.delivery_price
 


### PR DESCRIPTION
The _onchange_carrier_id inside the wizard was only called for delivery types 'Fixed' and 'Base on rule'.
But for some specific delivery methods, Odoo adds new delivery types (see delivery_ups_rest for eg).
The _get_shipment_rate method is computing the delivery prices for all delivery carrier types