### PR TITLE
[18.0] [FWPORT] [FIX] shopinvader_api_delivery_carrier: compute delivery price for all delivery types

### DIFF
--- a/shopinvader_api_delivery_carrier/routers/cart.py
+++ b/shopinvader_api_delivery_carrier/routers/cart.py
@@ -29,7 +29,7 @@ class CartHelper(VirtualModel):
         ctx = self.env.context.copy()
         ctx.update({"default_order_id": cart.id, "default_carrier_id": carrier_id})
         wizard = self.env["choose.delivery.carrier"].with_context(**ctx).create({})
-        wizard._onchange_carrier_id()
+        wizard._get_shipment_rate()
         wizard.button_confirm()
         return wizard.delivery_price
 

--- a/shopinvader_api_delivery_carrier/routers/cart.py
+++ b/shopinvader_api_delivery_carrier/routers/cart.py
@@ -29,7 +29,7 @@ class CartHelper(VirtualModel):
         ctx = self.env.context.copy()
         ctx.update({"default_order_id": cart.id, "default_carrier_id": carrier_id})
         wizard = self.env["choose.delivery.carrier"].with_context(**ctx).create({})
-        wizard._get_shipment_rate()
+        wizard._get_delivery_rate()
         wizard.button_confirm()
         return wizard.delivery_price
 


### PR DESCRIPTION
Forward port of #13 (`_get_shipment_rate` has been renamed to `_get_delivery_rate`)